### PR TITLE
BTAT-3407 Added sorting by due date in descending order

### DIFF
--- a/app/controllers/VatObligationsController.scala
+++ b/app/controllers/VatObligationsController.scala
@@ -61,15 +61,18 @@ class VatObligationsController @Inject()(val authenticate: AuthAction,
   private def desTransform(vatObligations: VatObligations, vrn: String): Obligations = {
     val found = vatObligations.obligations.map { vatObligation =>
       vatObligation.obligationDetails.map { obligationDetail =>
-        Obligation(obligationDetail.inboundCorrespondenceFromDate,
+        Obligation(
+          obligationDetail.inboundCorrespondenceFromDate,
           obligationDetail.inboundCorrespondenceToDate,
           obligationDetail.inboundCorrespondenceDueDate,
           obligationDetail.status,
-          obligationDetail.periodKey, obligationDetail.inboundCorrespondenceDateReceived)
+          obligationDetail.periodKey,
+          obligationDetail.inboundCorrespondenceDateReceived
+        )
       }
     }
 
-    Obligations(found.flatten)
+    Obligations(found.flatten.sortBy(_.due).reverse)
   }
 
   private def isInvalidVrn(vrn: String): Boolean = {

--- a/it/testData/ObligationData.scala
+++ b/it/testData/ObligationData.scala
@@ -44,9 +44,9 @@ object ObligationData {
   )
 
   val transformedSuccessResponse: Obligations = Obligations(Seq(
-    Obligation("1980-02-03", "1980-04-05", "1980-04-08", "F", "17AA", Some("1980-02-02")),
-    Obligation("1981-02-03", "1981-04-05", "1981-04-08", "F", "18AA", Some("1981-02-02")))
-  )
+    Obligation("1981-02-03", "1981-04-05", "1981-04-08", "F", "18AA", Some("1981-02-02")),
+    Obligation("1980-02-03", "1980-04-05", "1980-04-08", "F", "17AA", Some("1980-02-02"))
+  ))
 
   val singleErrorResponse: Error = Error("CODE", "ERROR MESSAGE")
 

--- a/test/controllers/VatObligationsControllerSpec.scala
+++ b/test/controllers/VatObligationsControllerSpec.scala
@@ -43,14 +43,14 @@ class VatObligationsControllerSpec extends SpecBase with MockVatObligationsServi
         Seq(
           ObligationDetail("F", "1980-02-03", "1980-04-05", Some("1980-02-02"), "1980-04-08", "17AA"),
           ObligationDetail("F", "1980-02-02", "1980-04-02", Some("1980-02-01"), "1980-04-07", "17AB"),
-          ObligationDetail("F", "1981-02-03", "1981-04-05", None, "1981-04-08", "17AC")
+          ObligationDetail("F", "1981-02-03", "1981-04-05", None, "1981-05-08", "17AC")
         )
       ),
         VatObligation(
           Seq(
             ObligationDetail("F", "1981-02-03", "1981-04-05", Some("1981-02-02"), "1981-04-08", "16AA"),
             ObligationDetail("F", "1981-02-02", "1981-04-02", Some("1981-02-01"), "1981-04-07", "16AB"),
-            ObligationDetail("F", "1982-02-03", "1982-04-05", None, "1982-04-08", "16AC")
+            ObligationDetail("F", "1982-02-03", "1982-04-05", None, "1982-05-08", "16AC")
           )
         )
       )
@@ -69,20 +69,18 @@ class VatObligationsControllerSpec extends SpecBase with MockVatObligationsServi
     )
 
   val transformedSuccessData: Obligations = Obligations(Seq(
-    Obligation("1980-02-03", "1980-04-05", "1980-04-08", "F", "17AA", Some("1980-02-02")),
-    Obligation("1981-02-03", "1981-04-05", "1981-04-08", "F", "18AA", Some("1981-02-02")))
-  )
+    Obligation("1981-02-03", "1981-04-05", "1981-04-08", "F", "18AA", Some("1981-02-02")),
+    Obligation("1980-02-03", "1980-04-05", "1980-04-08", "F", "17AA", Some("1980-02-02"))
+  ))
 
   val transformedMultipleObligationsSuccessData: Obligations = Obligations(Seq(
-    Obligation("1980-02-03", "1980-04-05", "1980-04-08", "F", "17AA", Some("1980-02-02")),
-    Obligation("1980-02-02", "1980-04-02", "1980-04-07", "F", "17AB", Some("1980-02-01")),
-    Obligation("1981-02-03", "1981-04-05", "1981-04-08", "F", "17AC", None),
-
+    Obligation("1982-02-03", "1982-04-05", "1982-05-08", "F", "16AC", None),
+    Obligation("1981-02-03", "1981-04-05", "1981-05-08", "F", "17AC", None),
     Obligation("1981-02-03", "1981-04-05", "1981-04-08", "F", "16AA", Some("1981-02-02")),
     Obligation("1981-02-02", "1981-04-02", "1981-04-07", "F", "16AB", Some("1981-02-01")),
-    Obligation("1982-02-03", "1982-04-05", "1982-04-08", "F", "16AC", None))
-
-  )
+    Obligation("1980-02-03", "1980-04-05", "1980-04-08", "F", "17AA", Some("1980-02-02")),
+    Obligation("1980-02-02", "1980-04-02", "1980-04-07", "F", "17AB", Some("1980-02-01"))
+  ))
 
   val singleError = Error(code = "CODE", reason = "ERROR MESSAGE")
   val multiError = MultiError(


### PR DESCRIPTION
If you wish to test this visually, here's a handy bit of JSON with jumbled up due dates:
```
{
  "_id": "/enterprise/obligation-data/vrn/987654321/VATC?from=2018-01-01&to=2018-12-31&status=O",
  "method": "GET",
  "status": 200,
  "response": {
    "obligations": [
      {
        "obligationDetails": [
          {
            "status": "O",
            "inboundCorrespondenceFromDate": "2017-01-01",
            "inboundCorrespondenceToDate": "2017-01-01",
            "inboundCorrespondenceDueDate": "2018-01-30",
            "periodKey": "18AA"
          },
          {
            "status": "O",
            "inboundCorrespondenceFromDate": "2017-01-01",
            "inboundCorrespondenceToDate": "2017-01-01",
            "inboundCorrespondenceDueDate": "2018-02-01",
            "periodKey": "18BB"
          },
          {
            "status": "O",
            "inboundCorrespondenceFromDate": "2017-01-01",
            "inboundCorrespondenceToDate": "2017-01-01",
            "inboundCorrespondenceDueDate": "2018-01-31",
            "periodKey": "18CC"
          },
          {
            "status": "O",
            "inboundCorrespondenceFromDate": "2017-01-01",
            "inboundCorrespondenceToDate": "2017-01-01",
            "inboundCorrespondenceDueDate": "2019-01-01",
            "periodKey": "19AA"
          }
        ]
      }
    ]
  }
}
```

Post that to the vat-obligations stub at `http://localhost:9158/setup/data` log in to our service as user 987654321 and go to the Return Deadlines page.